### PR TITLE
Include port state in Nmap report

### DIFF
--- a/1CommandTools.sh
+++ b/1CommandTools.sh
@@ -41,7 +41,7 @@ function run_recon {
     echo "Running Nmap..." >> "$summary_file"
     nmap_output=$(nmap -A -Pn $RHOST | grep -E "^[0-9]+/tcp.*open")
     echo "Open Ports and Services (Nmap):" >> "$summary_file"
-    echo "$nmap_output" | awk '{print $1, $3, $4}' >> "$summary_file"
+    echo "$nmap_output" | awk '{printf "%s %s %s", $1, $2, $3; for (i=4; i<=NF; i++) printf " %s", $i; print ""}' >> "$summary_file"
     echo "======================" >> "$summary_file"
 
     # Whois


### PR DESCRIPTION
## Summary
- Capture port, state, and service from Nmap output while retaining additional service details

## Testing
- `PATH="/tmp:$PATH" bash 1CommandTools.sh 1` *(with stubbed nmap & whois)*

------
https://chatgpt.com/codex/tasks/task_e_6899a15283488320a2fd81af4df8bde9