### PR TITLE
docs: standardize brute-force terminology

### DIFF
--- a/1CommandTools.sh
+++ b/1CommandTools.sh
@@ -6,7 +6,7 @@ source target.txt
 output_prefix=$(echo "$RHOST" | sed 's/\./_/g')  # Replace dots with underscores for filenames
 TARGET_URL_SANITIZED=$(echo "$TARGET_URL" | sed 's/[:\/\.]/_/g')  # Sanitize TARGET_URL for filenames
 
-mode=$1  # Mode: 0 = all, 1 = recon, 2 = directory listing, 3 = bruteforce scan
+mode=$1  # Mode: 0 = all, 1 = recon, 2 = directory listing, 3 = brute-force scan
 
 # Display Help/Usage information
 function display_help {
@@ -16,10 +16,10 @@ function display_help {
     echo ""
     echo "Arguments:"
     echo "  mode             The mode to run the script. Possible values are:"
-    echo "                   0  - Run all tests (recon, directory listing, bruteforce scanning)."
+    echo "                   0  - Run all tests (recon, directory listing, brute-force scanning)."
     echo "                   1  - Run reconnaissance tools like nmap, whois, dig, etc."
     echo "                   2  - Run directory listing tools like nikto, gobuster, etc."
-    echo "                   3  - Run bruteforce scanning tools."
+    echo "                   3  - Run brute-force scanning tools."
     echo ""
     echo "Examples:"
     echo "  $0 0"
@@ -80,14 +80,14 @@ function run_dir_list {
     echo "======================" >> "$summary_file"
 }
 
-# Bruteforce Scan (future option for brute force tools)
+# Brute-force Scan (future option for brute-force tools)
 function run_bruteforce_scan {
     summary_file="${TARGET_URL_SANITIZED}_summary_bruteforce.txt"
-    echo "Starting Bruteforce Scan on $TARGET_URL" > "$summary_file"
+    echo "Starting Brute-force Scan on $TARGET_URL" > "$summary_file"
     echo "======================" >> "$summary_file"
 
     # Placeholder for tools like wpscan, etc.
-    echo "Placeholder for bruteforce scan tools like wpscan." >> "$summary_file"
+    echo "Placeholder for brute-force scan tools like wpscan." >> "$summary_file"
     echo "======================" >> "$summary_file"
 }
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Use the provided `checkRequirements.sh` script to verify if all required tools a
 
 The main script `1CommandTools.sh` automates various pentesting tools based on the mode you select. The following modes are available:
 
-- `0`: Run **all tools** (Reconnaissance, Directory Listing, and Bruteforce Scanning)
+- `0`: Run **all tools** (Reconnaissance, Directory Listing, and Brute-force Scanning)
 - `1`: Run **Reconnaissance** tools (Nmap, Whois, Dig)
 - `2`: Run **Directory Listing** tools (Nikto, Gobuster, Wpscan)
-- `3`: Run **Bruteforce Scanning** tools (e.g., placeholder for future bruteforce tools)
+- `3`: Run **Brute-force Scanning** tools (e.g., placeholder for future brute-force tools)
 
 Each mode performs a specific set of tasks depending on the nature of the target.
 
@@ -84,7 +84,7 @@ Each mode performs a specific set of tasks depending on the nature of the target
    ./1CommandTools.sh 2
    ```
 
-4. Run Bruteforce Scanning Only (Placeholder):
+4. Run Brute-force Scanning Only (Placeholder):
    ```
    ./1CommandTools.sh 3
    ```


### PR DESCRIPTION
## Summary
- fix hyphenation of brute-force in README modes and examples
- update script comments and help text to use brute-force spelling

## Testing
- `bash -n 1CommandTools.sh`
- `bash 1CommandTools.sh -h`


------
https://chatgpt.com/codex/tasks/task_e_6899a1d61e648320936d5d0559497150